### PR TITLE
Fixed issue with invalid escape sequences in Windows path

### DIFF
--- a/invisibleroads_macros_log/__init__.py
+++ b/invisibleroads_macros_log/__init__.py
@@ -36,7 +36,7 @@ def format_summary(value_by_key, suffix_format_packs=None):
 
 
 def format_path(x):
-    return re.sub(r'^' + expanduser('~'), HOME_FOLDER_SHORT_PATH, x)
+    return re.sub(r'^' + re.escape(expanduser('~')), HOME_FOLDER_SHORT_PATH, x)
 
 
 def format_nested_dictionary(


### PR DESCRIPTION
This escapes the expanduser('~'), as on Windows it returns 'C:\User...' and re returns an invalid escape for '\U'.

```
Traceback (most recent call last):
  File "C:\Users\john\Projects\crosscompute\venv\Scripts\crosscompute-script.py", line 33, in <module>
    sys.exit(load_entry_point('crosscompute', 'console_scripts', 'crosscompute')())
  File "c:\users\john\projects\crosscompute\crosscompute\scripts\launch.py", line 37, in do
    automation = get_automation_from(args)
  File "c:\users\john\projects\crosscompute\crosscompute\scripts\launch.py", line 94, in get_automation_from
    path = configure_with(args)
  File "c:\users\john\projects\crosscompute\crosscompute\scripts\configure.py", line 50, in configure_with
    configuration, configuration_path = input_configuration_with(
  File "c:\users\john\projects\crosscompute\crosscompute\scripts\configure.py", line 73, in input_configuration_with
    'configuration path [%s]: ' % format_path(old_configuration_path))
  File "c:\users\john\projects\crosscompute\venv\lib\site-packages\invisibleroads_macros_log\__init__.py", line 39, in format_path
    return re.sub(r'^' + expanduser('~'), HOME_FOLDER_SHORT_PATH, x)
  File "C:\Python39\lib\re.py", line 210, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "C:\Python39\lib\re.py", line 304, in _compile
    p = sre_compile.compile(pattern, flags)
  File "C:\Python39\lib\sre_compile.py", line 764, in compile
    p = sre_parse.parse(p, flags)
  File "C:\Python39\lib\sre_parse.py", line 948, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
  File "C:\Python39\lib\sre_parse.py", line 443, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
  File "C:\Python39\lib\sre_parse.py", line 525, in _parse
    code = _escape(source, this, state)
  File "C:\Python39\lib\sre_parse.py", line 381, in _escape
    raise source.error("incomplete escape %s" % escape, len(escape))
re.error: incomplete escape \U at position 3
```